### PR TITLE
[CLS-1103] 웹 제품 브랜치에만 해당 Azure URL을 올려둔다

### DIFF
--- a/client/apps/web/src/contexts/HotkeyContext.tsx
+++ b/client/apps/web/src/contexts/HotkeyContext.tsx
@@ -54,7 +54,7 @@ export const HotkeyProvider: React.FC<HotkeyProviderProps> = ({ children, catego
   const handleFormSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
-    const res = await fetch(`https://api.closer.so/v1/retrieve/`, {
+    const res = await fetch(`https://api-dev.deskroom.so/v1/retrieve/`, {
       body: JSON.stringify({
         organization_key: currentOrg.key,
         question: formData?.answer,


### PR DESCRIPTION
* Azure OpenAI 성능 테스팅 위해 웹 제품에서만 OpenAI -> Azure OpenAI 호출로 바꾼다
* 현재 deskroom-dev에 올라가 있는 Azure 기반 retrieval로 URL 변경